### PR TITLE
Fix assertion failure due to packet buffer filling up

### DIFF
--- a/source/mqttd/client.d
+++ b/source/mqttd/client.d
@@ -175,7 +175,7 @@ struct Session
         ctx.timestamp = Clock.currTime;
         ctx.state = state;
 
-        if(_packets.capacity == 0)
+        if (_packets.full())
             _packets.popBack(); // make place by oldest one removal
 
         _packets.put(ctx);


### PR DESCRIPTION
Fixes:

```
core.exception.AssertError@../../.dub/packages/vibe-d-0.7.28/source/vibe/utils/array.d(357): Assertion failure
----------------
??:? _d_assert [0x91eebf]
??:? void vibe.utils.array.__assert(int) [0x9168c3]
../../.dub/packages/vibe-d-0.7.28/source/vibe/utils/array.d:357 void vibe.utils.array.__T15FixedRingBufferTS5mqttd6client13PacketContextVmi65535Vbi1Z.FixedRingBuffer.put!().put(mqttd.client.PacketContext) [0x76b33a]
../../.dub/packages/vibe-mqtt-0.1.2/source/mqttd/client.d:181 void mqttd.client.Session.add!(mqttd.messages.Publish).add(ref mqttd.messages.Publish, mqttd.client.PacketState) [0x76b2ca]
../../.dub/packages/vibe-mqtt-0.1.2/source/mqttd/client.d:333 void mqttd.client.MqttClient.publish!(immutable(char)[]).publish(const(immutable(char)[]), const(immutable(char)[]), mqttd.messages.QoSLevel, bool) [0x76b178]
source/app.d:166 _D3app17runSolrUpdateLoopFS5mqttd6client8SettingsAyaZ53__T9__lambda6TC4vibe4http6client18HTTPClientResponseZ9__lambda6MFMC4vibe4http6client18HTTPClientResponseZ14__foreachbody2MFKS4vibe4data4json4JsonZ9__lambda2MFS4vibe4data4json4JsonZv [0x74ff5f]
../../.dub/packages/vibe-d-0.7.28/source/vibe/core/core.d:486 void vibe.core.core.makeTaskFuncInfo!(void delegate(vibe.data.json.Json), vibe.data.json.Json).makeTaskFuncInfo(ref void delegate(vibe.data.json.Json), ref vibe.data.json.Json).callDelegate(vibe.core.core.TaskFuncInfo*) [0x7729c7]
../../.dub/packages/vibe-d-0.7.28/source/vibe/core/core.d:1084 void vibe.core.core.CoreTask.run() [0x8818c9]
??:? void core.thread.Fiber.run() [0x9798e9]
??:? fiber_entryPoint [0x97966b]
??:? [0xffffffff]
```

I am not sure this is correct for QoS > 0.
