### PR TITLE
Update vibe-d:utils dependency version

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,4 +6,4 @@ license "BSL-1.0"
 targetType "library"
 
 dependency "vibe-d:tls" version="~>0.8"
-dependency "vibe-d:utils" version="~>0.0.0"
+dependency "vibe-d:utils" version="~>0.8"


### PR DESCRIPTION
Hi @tchaloupka, sorry but I didn't see that PR #37 breaks the `dub test` command and the CI.
In my fork I've been using `0.8` as dependency version instead, to match `vibe-d:tls` dependency. I hope this will fix the CI :innocent: 